### PR TITLE
added support for max latency acceptable for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ To run this tool, you could run ``` docker run shonpaz123/s3bench ``` command to
 ```
 docker run shonpaz123/s3bench
 usage: s3bench.py [-h] -e ENDPOINT_URL -a ACCESS_KEY -s SECRET_KEY -b
-                         BUCKET_NAME -o OBJECT_SIZE -u ELASTIC_URL -n
-                         NUM_OBJECTS -w WORKLOAD [-c CLEANUP]
-s3bench: error: the following arguments are required: -e/--endpoint-url, -a/--access-key, -s/--secret-key, -b/--bucket-name, -o/--object-size, -u/--elastic-url, -n/--num-objects, -w/--workload
+                  BUCKET_NAME -o OBJECT_SIZE -u ELASTIC_URL -n NUM_OBJECTS -w
+                  WORKLOAD [-l MAX_LATENCY] [-c CLEANUP]
+s3bench.py: error: the following arguments are required: -e/--endpoint-url, -a/--access-key, -s/--secret-key, -b/--bucket-name, -o/--object-size, -u/--elastic-url, -n/--num-objects, -w/--workload
 ```
 Arguments between squrae brackets are optional, the regular ones are required. To enter the man page run the command ``` docker run shonpaz123/s3bench -h ```, for example: 
 
@@ -60,6 +60,8 @@ optional arguments:
                         number of objects to put/get
   -w WORKLOAD, --workload WORKLOAD
                         workload running on s3 - read/write
+  -l MAX_LATENCY, --max-latency MAX_LATENCY
+                        max acceptable latency per object operation in ms
   -c CLEANUP, --cleanup CLEANUP
                         should we cleanup all the object that were written
                         yes/no
@@ -108,7 +110,7 @@ CONTAINER ID        IMAGE                                                 COMMAN
 Run the benchmark (note the _CONTAINER ID_ from above):
 
 ```shell
-sudo docker run --link 7ed851e60565:elasticsearch shonpaz123/s3bench -e http://$(hostname):8000 -a ${ACCESS_KEY} -s ${SECRET_KEY} -b s3bench -o 65536 -n 1000000 -w write -c no -u elasticsearch:9200
+sudo docker run --link 7ed851e60565:elasticsearch shonpaz123/s3bench -e http://$(hostname):8000 -a ${ACCESS_KEY} -s ${SECRET_KEY} -b s3bench -o 65536 -n 1000000 -w write -l 10000 -c no -u elasticsearch:9200
 ```
 
 Run and connect to Kibana:

--- a/s3bench.py
+++ b/s3bench.py
@@ -58,7 +58,7 @@ class ObjectAnalyzer(object): #pylint: disable=too-many-instance-attributes
         self.object_name = ""
         self.num_objects = args.num_objects
         self.workload = args.workload
-        self.max_latency = args.max_latency
+self.max_latency = args.max_latency if args.max_latency else 0
         self.cleanup = args.cleanup
         self.s3 = boto3.client('s3', endpoint_url=self.endpoint_url, #pylint: disable=invalid-name
                                aws_access_key_id=self.access_key,

--- a/s3bench.py
+++ b/s3bench.py
@@ -132,7 +132,10 @@ class ObjectAnalyzer(object): #pylint: disable=too-many-instance-attributes
 
         return diff
 
-    def evaluate_latency(self, op_duration):
+def evaluate_latency(self, op_duration):
+    if op_duration > float(self.max_latency):
+        return 1
+    return 0
         lat_exceeded = 0
         if op_duration > float(self.max_latency):
             lat_exceeded = 1

--- a/s3bench.py
+++ b/s3bench.py
@@ -170,7 +170,7 @@ class ObjectAnalyzer(object): #pylint: disable=too-many-instance-attributes
 
     def list_random_objects(self):
         """This function returns randomized list of object in a bucket according to a given number
-        It chooses only objects of sizes specified by the user"""
+        In case number is bigger than 1000, use pagination, else use regular v2"""
         # in case number of objects is smaller then the page size, to save list costs
         if int(self.num_objects) <= 1000:
             objects = self.s3.list_objects(Bucket=self.bucket_name, MaxKeys=int(self.num_objects))


### PR DESCRIPTION
In order to allow clients to calculate error_rates related to latency, a flag is added to indicate when the latency for an operation has exceeded the one set by the client.

The flag is an integer rather than a boolean as it allows to later perform mathematical manipulations on the flag in order to calculate the total amount of time the latency provided by the system was higher than configured.